### PR TITLE
fix: claude-review ワークフローの direct_prompt を prompt に修正

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -34,6 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_bedrock: "true"
           claude_args: '--model "arn:aws:bedrock:ap-northeast-1:369264854262:application-inference-profile/0nd6go9xrzg0" --max-turns 20'
-          direct_prompt: |
+          prompt: |
             PR #${{ github.event.issue.number }} をレビューしてください。
             reviewing-pull-request スキルを使って、インラインコメントと総評を GitHub に投稿してください。


### PR DESCRIPTION
## Summary

- `anthropics/claude-code-action@v1` の有効な入力名は `prompt` だが、`direct_prompt` を使っていたため Warning が出てプロンプトが渡されていなかった
- `direct_prompt` → `prompt` に修正

## Test plan

- [ ] PR に `/request-review` コメントを投稿してワークフローが正常にレビューを投稿することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)