### PR TITLE
Fix YAML syntax in claude-review workflow permissions

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -35,12 +35,12 @@ jobs:
           use_bedrock: "true"
           claude_args: '--model "arn:aws:bedrock:ap-northeast-1:369264854262:application-inference-profile/0nd6go9xrzg0" --max-turns 20'
           additional_permissions: |
-            Bash(gh pr view:*)
-            Bash(gh repo view:*)
-            Bash(gh pr list:*)
-            Bash(gh api:*)
-            Bash(git diff:*)
-            Bash(git log:*)
+            Bash(gh pr view:*),
+            Bash(gh repo view:*),
+            Bash(gh pr list:*),
+            Bash(gh api:*),
+            Bash(git diff:*),
+            Bash(git log:*),
             Bash(git show:*)
           prompt: |
             PR #${{ github.event.issue.number }} をレビューしてください。


### PR DESCRIPTION
## Summary
Fixed YAML syntax error in the `claude-review.yaml` workflow file by adding missing commas to the `additional_permissions` list.

## Key Changes
- Added commas after each permission entry in the `additional_permissions` configuration to comply with YAML list syntax
- Affected permissions:
  - `Bash(gh pr view:*)`
  - `Bash(gh repo view:*)`
  - `Bash(gh pr list:*)`
  - `Bash(gh api:*)`
  - `Bash(git diff:*)`
  - `Bash(git log:*)`

## Details
The `additional_permissions` field is a multi-line YAML list that requires commas as delimiters between items. The last item (`Bash(git show:*)`) already had correct syntax. This fix ensures the workflow YAML is valid and will parse correctly.

https://claude.ai/code/session_01KneKRL9qEsMy2FQrarHBSw