### PR TITLE
fix: MembershipIDの冪等性破壊を修正 (#4)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,3 @@
-version: 2
+version: "2"
+
 

--- a/internal/consumer/read_model.go
+++ b/internal/consumer/read_model.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/oklog/ulid/v2"
 	"github.com/sudame/chat/internal/domain/membership"
 	"github.com/sudame/chat/internal/domain/room"
 	"github.com/sudame/chat/internal/domain/user"
@@ -82,9 +81,7 @@ func handleRoomCreatedEvent(ctx context.Context, client *dynamodb.Client, event 
 }
 
 func handleMembershipCreatedEvent(ctx context.Context, client *dynamodb.Client, event membership.MembershipCreatedEvent) error {
-	// FIXIT: membershipID をここで生成するのは意味不明なので要修正
-	membershipID := "membership:" + ulid.Make().String()
-	membership := Membership{Id: membershipID, RoomID: event.ChatRoomId, UserID: event.UserId}
+	membership := Membership{Id: event.Id, RoomID: event.ChatRoomId, UserID: event.UserId}
 	item, err := attributevalue.MarshalMap(membership)
 	if err != nil {
 		return fmt.Errorf("failed to construct attribute: %w", err)

--- a/internal/domain/membership/membership.go
+++ b/internal/domain/membership/membership.go
@@ -10,8 +10,9 @@ import (
 const MembershipCreatedEventType string = "membership.created"
 
 type MembershipCreatedEvent struct {
-	UserId     string
-	ChatRoomId string
+	Id         string `json:"id"`
+	UserId     string `json:"user_id"`
+	ChatRoomId string `json:"chat_room_id"`
 }
 
 // ToEnvelope implements [events.Event].
@@ -41,6 +42,7 @@ func CreateMembership(chatRoomId string, userId string) (*Membership, error) {
 	id := "membership-" + ulid.Make().String()
 
 	event := MembershipCreatedEvent{
+		Id:         id,
 		UserId:     userId,
 		ChatRoomId: chatRoomId,
 	}


### PR DESCRIPTION
## 概要

Issue #4「[Critical] MembershipIDを投影時に生成している（冪等性破壊）」を修正します。

## 変更内容

### 問題

`handleMembershipCreatedEvent` 内でMembershipのIDを投影時に `ulid.Make()` で生成していました。これはKafkaからの同一イベントを複数回処理した際に毎回異なるIDが生成されてしまい、冪等性を破壊していました。

### 修正

- `MembershipCreatedEvent` に `Id` フィールドを追加し、ドメイン層（`CreateMembership`）でMembershipIDを生成してイベントに含めるよう変更
- `MembershipCreatedEvent` の各フィールドにJSONタグを付与
- 投影側（`read_model.go`）では `event.Id` を使用してIDを取得するよう修正し、不要な `ulid` インポートを削除

### 変更ファイル

- `internal/domain/membership/membership.go` - `MembershipCreatedEvent` に `Id` フィールドとJSONタグを追加
- `internal/consumer/read_model.go` - 投影時のID生成を廃止し `event.Id` を使用
- `.golangci.yml` - `version` フィールドの型を文字列に修正

## 関連Issue

Closes #4