### PR TITLE
ci: add Go build and lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
+          cache: true
       - run: go build ./...
 
   lint:
@@ -22,7 +23,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
+          cache: true
       - uses: golangci/golangci-lint-action@v9
 
   test:
@@ -31,5 +33,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
+          cache: true
       - run: go test ./...


### PR DESCRIPTION
## Summary
- Go の `build` と `lint` チェックを行う CI ワークフローを追加
- `push`（main）と `pull_request`（main）で実行される
- golangci-lint-action v9 による lint チェック

## Test plan
- [ ] PR 作成時にワークフローが実行されることを確認
- [ ] build ジョブが正常に完了することを確認
- [ ] lint ジョブが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)