### PR TITLE
Dependabot の設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## 概要

Dependabot の設定ファイル（`.github/dependabot.yml`）を追加し、依存関係の自動更新を有効にします。

## 変更内容

以下の3つのエコシステムを **毎日** チェックする設定を追加:

- **gomod** - Go の依存関係（`go.mod`）
- **docker** - Docker イメージ（`compose.yml`）
- **github-actions** - GitHub Actions のアクションバージョン