### PR TITLE
fix(ci): add explicit permissions to restrict GITHUB_TOKEN scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [v3]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- CIワークフロー（`.github/workflows/ci.yml`）にワークフローレベルの `permissions: contents: read` を追加
- `GITHUB_TOKEN` のスコープを最小権限に制限

## 関連Issue

- Resolves https://github.com/sudame-teasobi/toy-chat-app/security/code-scanning/1
- Resolves https://github.com/sudame-teasobi/toy-chat-app/security/code-scanning/2
- Resolves https://github.com/sudame-teasobi/toy-chat-app/security/code-scanning/3

## 変更内容

CodeQL が検出した `actions/missing-workflow-permissions` アラート3件（build, lint, test ジョブ）を解消するため、ワークフローのトップレベルに `permissions` ブロックを追加しました。これにより全ジョブに対して最小権限の原則が適用されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)