### PR TITLE
fix: claude-code-action から不要な github_token 指定を削除

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -35,7 +35,6 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           use_bedrock: "true"
           claude_args: |
             --model "arn:aws:bedrock:ap-northeast-1:369264854262:application-inference-profile/0nd6go9xrzg0"


### PR DESCRIPTION
## Summary

- `claude-code-action` の設定から `github_token: ${{ secrets.GITHUB_TOKEN }}` の指定を削除
- このトークンはアクション側でデフォルトで利用されるため、明示的な指定は不要

## 変更内容

`.github/workflows/claude-code.yaml` から `github_token` パラメータの1行を削除。

## Test plan

- [x] GitHub Actions のワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)