### PR TITLE
fix: Kafka環境変数の読み込みとコンシューマーグループ競合を修正 (#12)

### DIFF
--- a/cmd/membership/main.go
+++ b/cmd/membership/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sudame/chat/internal/infrastructure/repository"
 	"github.com/sudame/chat/internal/service"
 	"github.com/sudame/chat/internal/ticdc"
+	"github.com/sudame/chat/pkg/env"
 	"github.com/sudame/chat/pkg/httpclient"
 )
 
@@ -31,6 +32,7 @@ func main() {
 	ctx := context.Background()
 
 	kafkaBroker := getEnv("KAFKA_BROKER", "localhost:9092")
+	kafkaGroupID := env.GetEnv("KAFKA_GROUP_ID").Value()
 
 	host := getEnv("DB_HOST", "localhost")
 	port := getEnv("DB_PORT", "4000")
@@ -72,7 +74,7 @@ func main() {
 	reader := kafka.NewReader(
 		kafka.ReaderConfig{
 			Brokers:     []string{kafkaBroker},
-			GroupID:     "membership-consumer-group",
+			GroupID:     kafkaGroupID,
 			GroupTopics: []string{"event-records-changefeed"},
 		},
 	)

--- a/cmd/read/main.go
+++ b/cmd/read/main.go
@@ -22,15 +22,17 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	slog.SetDefault(logger)
 
-	dynamodbURL, err := env.GetEnv("DYNAMODB_URL").Value()
+	dynamodbURL, err := env.GetEnv("DYNAMODB_URL").SafeValue()
 	if err != nil {
 		panic("failed to get env: DYNAMODB_URL")
 	}
 
-	kafkaBroker, err := env.GetEnv("KAFKA_BROKER").WithDefault("localhost:9092").Value()
+	kafkaBroker, err := env.GetEnv("KAFKA_BROKER").WithDefault("localhost:9092").SafeValue()
 	if err != nil {
 		log.Fatalf("failed to get env KAFKA_BROKER: %s", err)
 	}
+
+	kafkaGroupID := env.GetEnv("KAFKA_GROUP_ID").Value()
 
 	slog.DebugContext(ctx, "dynamodb", "dynamodb_url", dynamodbURL)
 
@@ -57,7 +59,7 @@ func main() {
 	reader := kafka.NewReader(
 		kafka.ReaderConfig{
 			Brokers:     []string{kafkaBroker},
-			GroupID:     "read-model-consumer-group",
+			GroupID:     kafkaGroupID,
 			GroupTopics: []string{"event-records-changefeed"},
 		},
 	)

--- a/compose.yml
+++ b/compose.yml
@@ -175,7 +175,7 @@ services:
       DB_NAME: toy_chat_app
       KAFKA_BROKER: kafka:29092
       KAFKA_TOPIC: event-records-changefeed
-      KAFKA_GROUP_ID: event-consumer-group
+      KAFKA_GROUP_ID: membership-consumer-group
       ROOM_SERVER: "http://write-server:8081"
 
   read:
@@ -190,7 +190,7 @@ services:
     environment:
       KAFKA_BROKER: kafka:29092
       KAFKA_TOPIC: event-records-changefeed
-      KAFKA_GROUP_ID: event-consumer-group
+      KAFKA_GROUP_ID: read-consumer-group
       DYNAMODB_URL: "http://dynamodb:8000"
 
   ##########################################

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -15,7 +15,7 @@ func (e *env) WithDefault(defaultValue string) *env {
 	return e
 }
 
-func (e *env) Value() (string, error) {
+func (e *env) SafeValue() (string, error) {
 	if e.value != "" {
 		return e.value, nil
 	}
@@ -26,6 +26,14 @@ func (e *env) Value() (string, error) {
 
 	return "", fmt.Errorf("failed to get env and default value is not set")
 
+}
+
+func (e *env) Value() string {
+	value, err := e.SafeValue()
+	if err != nil {
+		panic(fmt.Sprintf("failed to read environment: %s", err.Error()))
+	}
+	return value
 }
 
 func GetEnv(key string) *env {


### PR DESCRIPTION
## Summary

- `cmd/read/main.go` と `cmd/membership/main.go` で `KAFKA_GROUP_ID` 環境変数を読み込むように修正
- `compose.yml` で各サービスに別々のコンシューマーグループIDを設定（`read-consumer-group` / `membership-consumer-group`）
- `pkg/env/env.go` に必要なヘルパーを追加

## 関連Issue

Closes #12

## 変更内容

- **環境変数の反映**: `KAFKA_GROUP_ID` がハードコードされていた箇所を `env.GetEnv("KAFKA_GROUP_ID")` で環境変数から取得するよう修正
- **グループID競合の解消**: `compose.yml` で `read` と `membership` サービスにそれぞれ別のグループIDを設定し、メッセージの取り合いを防止

🤖 Generated with [Claude Code](https://claude.com/claude-code)