### PR TITLE
fix: #13 getEnv 関数の重複を pkg/env パッケージに統一

### DIFF
--- a/cmd/membership/main.go
+++ b/cmd/membership/main.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
-	"os"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/segmentio/kafka-go"
@@ -21,26 +20,19 @@ import (
 	"github.com/sudame/chat/pkg/httpclient"
 )
 
-func getEnv(key string, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return defaultValue
-}
-
 func main() {
 	ctx := context.Background()
 
-	kafkaBroker := getEnv("KAFKA_BROKER", "localhost:9092")
+	kafkaBroker := env.GetEnv("KAFKA_BROKER").WithDefault("localhost:9092").Value()
 	kafkaGroupID := env.GetEnv("KAFKA_GROUP_ID").Value()
 
-	host := getEnv("DB_HOST", "localhost")
-	port := getEnv("DB_PORT", "4000")
-	user := getEnv("DB_USER", "root")
-	password := getEnv("DB_PASSWORD", "")
-	dbName := getEnv("DB_NAME", "toy_chat_app")
+	host := env.GetEnv("DB_HOST").WithDefault("localhost").Value()
+	port := env.GetEnv("DB_PORT").WithDefault("4000").Value()
+	user := env.GetEnv("DB_USER").WithDefault("root").Value()
+	password := env.GetEnv("DB_PASSWORD").WithDefault("").Value()
+	dbName := env.GetEnv("DB_NAME").WithDefault("toy_chat_app").Value()
 
-	roomServerBaseURL := getEnv("ROOM_SERVER", "")
+	roomServerBaseURL := env.GetEnv("ROOM_SERVER").Value()
 
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true", user, password, host, port, dbName)
 

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -4,11 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/sudame/chat/pkg/env"
 )
 
 func main() {
@@ -19,11 +19,11 @@ func main() {
 	)
 	flag.Parse()
 
-	host := getEnv("DB_HOST", "localhost")
-	port := getEnv("DB_PORT", "4000")
-	user := getEnv("DB_USER", "root")
-	password := getEnv("DB_PASSWORD", "")
-	dbName := getEnv("DB_NAME", "toy_chat_app")
+	host := env.GetEnv("DB_HOST").WithDefault("localhost").Value()
+	port := env.GetEnv("DB_PORT").WithDefault("4000").Value()
+	user := env.GetEnv("DB_USER").WithDefault("root").Value()
+	password := env.GetEnv("DB_PASSWORD").WithDefault("").Value()
+	dbName := env.GetEnv("DB_NAME").WithDefault("toy_chat_app").Value()
 
 	// TiDB compatibility settings:
 	// - tidb_skip_isolation_level_check=1: Skip SERIALIZABLE isolation level check
@@ -91,11 +91,4 @@ func main() {
 	default:
 		log.Fatalf("Unknown command: %s", *command)
 	}
-}
-
-func getEnv(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return defaultValue
 }

--- a/cmd/read/main.go
+++ b/cmd/read/main.go
@@ -22,16 +22,8 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	slog.SetDefault(logger)
 
-	dynamodbURL, err := env.GetEnv("DYNAMODB_URL").SafeValue()
-	if err != nil {
-		panic("failed to get env: DYNAMODB_URL")
-	}
-
-	kafkaBroker, err := env.GetEnv("KAFKA_BROKER").WithDefault("localhost:9092").SafeValue()
-	if err != nil {
-		log.Fatalf("failed to get env KAFKA_BROKER: %s", err)
-	}
-
+	dynamodbURL := env.GetEnv("DYNAMODB_URL").Value()
+	kafkaBroker := env.GetEnv("KAFKA_BROKER").WithDefault("localhost:9092").Value()
 	kafkaGroupID := env.GetEnv("KAFKA_GROUP_ID").Value()
 
 	slog.DebugContext(ctx, "dynamodb", "dynamodb_url", dynamodbURL)

--- a/cmd/write-server/main.go
+++ b/cmd/write-server/main.go
@@ -13,16 +13,20 @@ import (
 	"github.com/sudame/chat/internal/handler"
 	"github.com/sudame/chat/internal/infrastructure/repository"
 	"github.com/sudame/chat/internal/service"
+	"github.com/sudame/chat/pkg/env"
 )
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	slog.SetDefault(logger)
-	host := getEnv("DB_HOST", "localhost")
-	port := getEnv("DB_PORT", "4000")
-	user := getEnv("DB_USER", "root")
-	password := getEnv("DB_PASSWORD", "")
-	dbName := getEnv("DB_NAME", "toy_chat_app")
+
+	host := env.GetEnv("DB_HOST").WithDefault("localhost").Value()
+	port := env.GetEnv("DB_PORT").WithDefault("4000").Value()
+	user := env.GetEnv("DB_USER").WithDefault("root").Value()
+	password := env.GetEnv("DB_PASSWORD").WithDefault("").Value()
+	dbName := env.GetEnv("DB_NAME").WithDefault("toy_chat_app").Value()
+
+	serverPort := env.GetEnv("SERVER_PORT").WithDefault("8080").Value()
 
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true", user, password, host, port, dbName)
 
@@ -75,16 +79,8 @@ func main() {
 	e.POST("/create-chat-room", createRoomHandler.Handle)
 	e.POST("/check-room-existence", checkRoomExistenceHandler.Handle)
 
-	serverPort := getEnv("SERVER_PORT", "8080")
 	log.Printf("Starting server on port %s", serverPort)
 	if err := e.Start(":" + serverPort); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
-}
-
-func getEnv(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return defaultValue
 }


### PR DESCRIPTION
## Summary

Closes #13

複数の `cmd/*/main.go` に重複定義されていたローカルの `getEnv` 関数を削除し、`pkg/env` パッケージを使用するように統一しました。

## 変更内容

- `cmd/write-server/main.go` - ローカル `getEnv` を削除し `env.GetEnv().WithDefault().Value()` に置換
- `cmd/membership/main.go` - 同上
- `cmd/migrate/main.go` - 同上
- `cmd/read/main.go` - 不要だった `SafeValue()` の使用を `Value()` に簡略化

## Test plan

- [ ] `go build ./...` でビルドが通ること
- [ ] 環境変数の読み込みが従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)