### PR TITLE
fix: User・Membership アグリゲートに ClearEvents() を追加 (#15)

### DIFF
--- a/internal/domain/membership/membership.go
+++ b/internal/domain/membership/membership.go
@@ -28,3 +28,16 @@ func CreateMembership(chatRoomId string, userId string) (*Membership, error) {
 		Events:     []events.Event{&event},
 	}, nil
 }
+
+func ReconstructMembership(id string, chatRoomID string, userID string) *Membership {
+	return &Membership{
+		Id:         id,
+		ChatRoomId: chatRoomID,
+		UserId:     userID,
+		Events:     []events.Event{},
+	}
+}
+
+func (m *Membership) ClearEvents() {
+	m.Events = []events.Event{}
+}

--- a/internal/domain/room/room.go
+++ b/internal/domain/room/room.go
@@ -46,15 +46,15 @@ func ReconstructRoom(id string, name string) *Room {
 	}
 }
 
-func (cr *Room) ID() string   { return cr.id }
-func (cr *Room) Name() string { return cr.name }
+func (r *Room) ID() string   { return r.id }
+func (r *Room) Name() string { return r.name }
 
 // Events returns all recorded domain events.
-func (cr *Room) Events() []events.Event {
-	return cr.events
+func (r *Room) Events() []events.Event {
+	return r.events
 }
 
 // ClearEvents clears recorded events after persistence.
-func (cr *Room) ClearEvents() {
-	cr.events = make([]events.Event, 0)
+func (r *Room) ClearEvents() {
+	r.events = make([]events.Event, 0)
 }

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -35,9 +35,14 @@ func NewUser(name string) (*User, error) {
 // ReconstructChatRoom reconstructs a ChatRoom from persistence.
 func ReconstructUser(id string, name string) *User {
 	return &User{
-		id:   id,
-		name: name,
+		id:     id,
+		name:   name,
+		events: []events.Event{},
 	}
+}
+
+func (u *User) ClearEvents() {
+	u.events = []events.Event{}
 }
 
 func (u *User) ID() string             { return u.id }

--- a/internal/infrastructure/repository/chatroom_repository.go
+++ b/internal/infrastructure/repository/chatroom_repository.go
@@ -28,17 +28,17 @@ func NewChatRoomRepository(database *sql.DB) *ChatRoomRepository {
 
 // Save persists a chat room and its events to TiDB.
 // It processes events to determine which operations to perform.
-func (r *ChatRoomRepository) Save(ctx context.Context, cr *room.Room) error {
-	tx, err := r.db.BeginTx(ctx, nil)
+func (repo *ChatRoomRepository) Save(ctx context.Context, r *room.Room) error {
+	tx, err := repo.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	qtx := r.queries.WithTx(tx)
+	qtx := repo.queries.WithTx(tx)
 
 	// Process events to determine operations
-	for _, event := range cr.Events() {
+	for _, event := range r.Events() {
 		envelope, err := event.ToEnvelope()
 		if err != nil {
 			return err
@@ -47,8 +47,8 @@ func (r *ChatRoomRepository) Save(ctx context.Context, cr *room.Room) error {
 		case room.ChatRoomCreatedEventType:
 			// Insert chat room only when ChatRoomCreatedEvent exists
 			_, err = qtx.CreateChatRoom(ctx, db.CreateChatRoomParams{
-				ID:   cr.ID(),
-				Name: cr.Name(),
+				ID:   r.ID(),
+				Name: r.Name(),
 			})
 			if err != nil {
 				return err
@@ -65,12 +65,13 @@ func (r *ChatRoomRepository) Save(ctx context.Context, cr *room.Room) error {
 		}
 	}
 
+	r.ClearEvents()
 	return tx.Commit()
 }
 
 // FindByID retrieves a chat room by ID from TiDB.
-func (r *ChatRoomRepository) FindByID(ctx context.Context, id string) (*room.Room, error) {
-	row, err := r.queries.GetChatRoom(ctx, id)
+func (repo *ChatRoomRepository) FindByID(ctx context.Context, id string) (*room.Room, error) {
+	row, err := repo.queries.GetChatRoom(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, room.ErrNotFound

--- a/internal/infrastructure/repository/membership_repository.go
+++ b/internal/infrastructure/repository/membership_repository.go
@@ -85,5 +85,6 @@ func (r *MembershipRepository) Save(ctx context.Context, m *membership.Membershi
 		}
 	}
 
+	m.ClearEvents()
 	return tx.Commit()
 }

--- a/internal/infrastructure/repository/user_repository.go
+++ b/internal/infrastructure/repository/user_repository.go
@@ -67,6 +67,7 @@ func (r *UserRepository) Save(ctx context.Context, u *user.User) error {
 		}
 	}
 
+	u.ClearEvents()
 	return tx.Commit()
 }
 


### PR DESCRIPTION
## Summary

- `User` と `Membership` アグリゲートに `ClearEvents()` メソッドを追加
- 各リポジトリの `Save()` メソッドでコミット前に `ClearEvents()` を呼び出すように修正
- `Membership` に `ReconstructMembership()` ファクトリメソッドを追加
- `User` の `ReconstructUser()` で `events` フィールドを空スライスで初期化するよう修正
- `Room` ドメインおよび `ChatRoomRepository` のレシーバ名を統一（`cr` → `r` / `repo`）

## 背景

`Room` アグリゲートには `ClearEvents()` があったが、`User` と `Membership` にはなかった。リポジトリで保存後にイベントをクリアしないと、同じインスタンスを再保存した際に `event_records` テーブルへ重複イベントが挿入される問題があった。

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)