### PR TITLE
fix: Claude Code の認証を Bedrock から OAuth トークンに変更

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -4,7 +4,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write
 
 on:
   issue_comment:
@@ -17,27 +16,20 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      github.event.sender.login == 'sudame' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      )
     runs-on: ubuntu-latest
-    env:
-      AWS_REGION: ap-northeast-1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Configure AWS Credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ap-northeast-1
-
       - uses: anthropics/claude-code-action@v1
         with:
-          use_bedrock: "true"
           claude_args: |
-            --model "arn:aws:bedrock:ap-northeast-1:369264854262:application-inference-profile/0nd6go9xrzg0"
             --max-turns 10
             --allowedTools
               Bash(gh pr view:*),
@@ -49,3 +41,5 @@ jobs:
               Bash(git show:*),
               Bash(git branch:*),
               Skill(reviewing-pull-request:*)
+        env:
+          CLAUDE_OAUTH_TOKEN: ${{ secrets.CLAUDE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -4,7 +4,6 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  id-token: write
 
 on:
   issue_comment:
@@ -13,28 +12,19 @@ on:
 jobs:
   claude-review:
     if: |
+      github.event.sender.login == 'sudame' &&
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '/request-review')
     runs-on: ubuntu-latest
-    env:
-      AWS_REGION: ap-northeast-1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Configure AWS Credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ap-northeast-1
-
       - uses: anthropics/claude-code-action@v1
         with:
-          use_bedrock: "true"
           claude_args: |
-            --model "arn:aws:bedrock:ap-northeast-1:369264854262:application-inference-profile/0nd6go9xrzg0"
             --max-turns 20
             --allowedTools
               Bash(gh pr view:*),
@@ -50,3 +40,5 @@ jobs:
             PR #${{ github.event.issue.number }} をレビューしてください。
             レビュー前に、PR の過去のコメント・レビュー・インラインコメントへの返信をすべて確認し、開発者の意見や反論を理解した上でレビューしてください。
             /reviewing-pull-request を使って、インラインコメントと総評を GitHub に投稿してください。
+        env:
+          CLAUDE_OAUTH_TOKEN: ${{ secrets.CLAUDE_OAUTH_TOKEN }}


### PR DESCRIPTION
## 概要

Claude Code の GitHub Actions ワークフロー（`claude-code.yaml`, `claude-review.yaml`）の認証方式を AWS Bedrock + OIDC から OAuth トークン（`CLAUDE_OAUTH_TOKEN`）に切り替える。

## 変更内容

- AWS Bedrock + OIDC 認証関連の設定を削除（`id-token: write`, `AWS_REGION`, `configure-aws-credentials` ステップ, `use_bedrock`, Bedrock ARN モデル指定）
- `CLAUDE_OAUTH_TOKEN` による認証に切り替え
- ワークフローの実行を `sudame` のみに制限

## 前提条件

- GitHub Secrets に `CLAUDE_OAUTH_TOKEN` が設定済みであること