### PR TITLE
fix: Claude Code の認証を Bedrock から OAuth トークンに変更

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH?TOKEN }}
           claude_args: |
             --max-turns 10
             --allowedTools
@@ -41,5 +42,3 @@ jobs:
               Bash(git show:*),
               Bash(git branch:*),
               Skill(reviewing-pull-request:*)
-        env:
-          CLAUDE_OAUTH_TOKEN: ${{ secrets.CLAUDE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -24,6 +24,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH?TOKEN }}
           claude_args: |
             --max-turns 20
             --allowedTools
@@ -40,5 +41,3 @@ jobs:
             PR #${{ github.event.issue.number }} をレビューしてください。
             レビュー前に、PR の過去のコメント・レビュー・インラインコメントへの返信をすべて確認し、開発者の意見や反論を理解した上でレビューしてください。
             /reviewing-pull-request を使って、インラインコメントと総評を GitHub に投稿してください。
-        env:
-          CLAUDE_OAUTH_TOKEN: ${{ secrets.CLAUDE_OAUTH_TOKEN }}


### PR DESCRIPTION
## 概要

Claude Code GitHub Actions の認証方式を AWS Bedrock (OIDC) から OAuth トークンに変更しました。

## 変更内容

- **認証方式の変更**: AWS Bedrock + OIDC 認証から `claude_code_oauth_token` による認証に切り替え
- **AWS 関連設定の削除**: `id-token` パーミッション、AWS credentials 設定ステップ、Bedrock モデル ARN 指定を削除
- **実行制限の追加**: `github.event.sender.login == 'sudame'` の条件を追加し、sudame のみが Claude Code を実行可能に

## 対象ファイル

- `.github/workflows/claude-code.yaml`
- `.github/workflows/claude-review.yaml`